### PR TITLE
fix: shading activates despite open window when manual wait time expires

### DIFF
--- a/src/CallContext.h
+++ b/src/CallContext.h
@@ -15,6 +15,7 @@ class CallContext
         bool modeNewStarted = false;
         bool fastSimulationActive = false;
         bool isWindowOpenActive = false;
+        bool isWindowTiltActive = false;
         bool hasSlat = false;
         bool diagnosticLog = false;
         bool shadingControlActive = false;

--- a/src/ModeShading.cpp
+++ b/src/ModeShading.cpp
@@ -356,6 +356,10 @@ bool ModeShading::allowed(const CallContext &callContext)
         return false;
     if (startWaitTimeActive)
         return false;
+    if (callContext.isWindowTiltActive && !windowTiltAllowed())
+        return false;
+    if (callContext.isWindowOpenActive && !callContext.isWindowTiltActive && !windowOpenAllowed())
+        return false;
     if (stopWaitTimeActive)
         return true;
     if (!allowedByHeatingOff)

--- a/src/ShutterControllerChannel.cpp
+++ b/src/ShutterControllerChannel.cpp
@@ -595,6 +595,7 @@ void ShutterControllerChannel::execute(CallContext &callContext)
             _currentWindowOpenHandler->start(callContext, _currentWindowOpenHandler, _positionController);
     }
     callContext.isWindowOpenActive = _currentWindowOpenHandler != nullptr;
+    callContext.isWindowTiltActive = _currentWindowOpenHandler != nullptr && _currentWindowOpenHandler->isTiltHandler();
 
     // State machine handling for mode activation
     ModeBase *nextMode = nullptr;

--- a/src/WindowOpenHandler.h
+++ b/src/WindowOpenHandler.h
@@ -26,6 +26,7 @@ public:
 protected:
     const std::string& logPrefix() const;
 public:
+    bool isTiltHandler() const { return _isTiltHandler; }
     uint8_t getParamterOpenPositionControl();
     uint8_t getParamterOpenSlatPositionControl();
     uint8_t getParamterOpenPosition();


### PR DESCRIPTION
ModeShading::allowed() hat den Diagnose-Flag _notAllowedReason für „Fenster offen" (Grund 14) korrekt gesetzt, den Fensterzustand aber nicht in den tatsächlichen Rückgabewert einbezogen. Dadurch wurde die Beschattung nach Ablauf der Wartezeit für die Reaktivierung nach Handbetrieb wieder aktiv, obwohl das Fenster noch geöffnet war.

isWindowTiltActive zum CallContext hinzugefügt, um zwischen „Fenster offen" und „Fenster gekippt" zu unterscheiden. isTiltHandler() getter zu WindowOpenHandler hinzugefügt.
In ModeShading::allowed() wird nun false zurückgegeben, wenn das Fenster geöffnet ist und windowOpenAllowed() false ist, bzw. wenn das Fenster gekippt ist und windowTiltAllowed() false ist.